### PR TITLE
adds support for customer_asn to pureport_aws_connection

### DIFF
--- a/pureport/resource_pureport_aws_connection.go
+++ b/pureport/resource_pureport_aws_connection.go
@@ -84,12 +84,14 @@ func expandAWSConnection(d *schema.ResourceData) client.AwsDirectConnectConnecti
 
 	// Generic Connection values
 	speed := d.Get("speed").(int)
+	customer_asn := d.Get("customer_asn").(int)
 
 	// Create the body of the request
 	c := client.AwsDirectConnectConnection{
-		Type_: "AWS_DIRECT_CONNECT",
-		Name:  d.Get("name").(string),
-		Speed: int32(speed),
+		Type_:       "AWS_DIRECT_CONNECT",
+		Name:        d.Get("name").(string),
+		Speed:       int32(speed),
+		CustomerASN: int64(customer_asn),
 		Location: &client.Link{
 			Href: d.Get("location_href").(string),
 		},

--- a/website/docs/r/aws_connection.html.md
+++ b/website/docs/r/aws_connection.html.md
@@ -72,6 +72,7 @@ The following arguments are supported:
 
 - - -
 * `description` - (Optional) The description for the connection.
+* `customer_asn` - (Optional) The BGP ASN number to use for the customer network 
 * `customer_networks` - (Optional) A list of named CIDR block to easily identify a customer network.
     * `name` - The name for the network.
     * `address` - The CIDR block for the network


### PR DESCRIPTION
This commit adds support for configuring the customer BGP ASN number
when creating or updateing AWS connections.  The customer_asn value can
be set on the pureport_aws_connection resource. The customer_asn value
expects an integer.

For example:

```
resource "pureport_aws_connection" "main" {
  name = "AwsDirectConnectTest"

  speed             = 50
  high_availability = true

  location_href = var.pureport_location
  network_href  = pureport_network.main.href

  customer_asn = 65123

  aws_region     = "us-east-1"
  aws_account_id = var.aws_account_id
}

```

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>